### PR TITLE
Develop

### DIFF
--- a/src/Supergiros.php
+++ b/src/Supergiros.php
@@ -35,7 +35,6 @@ class Supergiros
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_PROXY, 'http://77d5838c880c44e8e90480f1e40f5b801c64ccb8:@proxy.zenrows.com:8001');
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);

--- a/src/Supergiros.php
+++ b/src/Supergiros.php
@@ -13,6 +13,7 @@ class Supergiros
     public function call($date)
     {
         $html = $this->getResponse($date);
+
         $data = $this->tarnsform($html);
         return $data;
     }
@@ -20,27 +21,27 @@ class Supergiros
     private function getResponse($date)
     {
         $url = 'https://supergirosatlantico.com.co/tabla-resultados/';
-
-        $paramenters = [
+        $parameters = [
             'nombre' => '',
             'fecha' => $date,
             'enviar' => 'consultar'
         ];
 
-        $defaults = [
-            CURLOPT_POST => true,
-            CURLOPT_POSTFIELDS => $paramenters,
-            CURLOPT_RETURNTRANSFER => true,
+        $headers = [
+            'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+            'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
         ];
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-        curl_setopt_array($ch, $defaults);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $parameters);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
         $response = curl_exec($ch);
         curl_close($ch);
         return $response;


### PR DESCRIPTION
This pull request updates the `Supergiros` class to improve how HTTP requests are made to the Supergiros Atlantico results page. The main changes focus on correcting parameter naming, switching from a GET to a POST request, and enhancing request headers for better compatibility.

HTTP request improvements:

* Changed the request from a GET to a POST, sending parameters via `CURLOPT_POSTFIELDS` for proper form submission.
* Added custom HTTP headers (`User-Agent` and `Accept`) to better mimic a browser and improve response reliability.

Code quality and bug fixes:

* Fixed a typo by renaming `$paramenters` to `$parameters` for consistency and clarity.
* Removed unused `$defaults` array and set cURL options directly for better readability and maintainability.
* Removed proxy configuration and unnecessary cURL options, simplifying the request setup.